### PR TITLE
Add support for `--changed`

### DIFF
--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -41,7 +41,7 @@ TOOLS = [
 ]
 
 
-def execute_tools(fix: bool, files: Tuple[str]) -> Iterable[bool]:
+def execute_tools(fix: bool, files: Tuple[str, ...]) -> Iterable[bool]:
     tools = TOOLS
     if fix:
         tools = [tool for tool in tools if tool.fixable]

--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -77,7 +77,7 @@ def get_changed_files() -> Iterable[str]:
             ],
             stdout=subprocess.PIPE,
         )
-        return result.stdout.decode('utf8').strip().split(' ')
+        return result.stdout.decode('utf8').strip().split('\n')
     except subprocess.CalledProcessError:
         raise Exception('Error encountered when determining changed files.')
 


### PR DESCRIPTION
This PR does a few things:
* commands can be run on arbitrary files instead of just `.`
* a shortcut for running only on staged files is added with the flag `--changed`
  - if this flag is specified and no files are staged, linting is skipped 
* the tool no longer exits with status code `1` when run with `--fix`
* `--fix` and `--changed` operate independently, and can be specified together or separately
* `--changed` works alongside specifying files, so `lintlizard --changed my_file.py` would run on both staged files and `my_file.py`