### PR TITLE
Fix flake8 file specification

### DIFF
--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -37,7 +37,7 @@ class CommandTool:
 
 
 TOOLS = [
-    CommandTool('flake8', default_files=('.',)),
+    CommandTool('flake8', default_files=()),
     CommandTool(
         'isort', run_params=('-c',), fix_params=tuple(), default_files=('.',)
     ),
@@ -64,7 +64,7 @@ def execute_tools(fix: bool, files: Tuple[str, ...]) -> Iterable[bool]:
                 if fix and tool.fix_params is not None
                 else tool.run_command()
             )
-            if tool.default_files:
+            if tool.default_files is not None:
                 cmd = cmd + (files or tool.default_files)
             subprocess.run(args=cmd, check=True)
         except subprocess.CalledProcessError:

--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -37,7 +37,7 @@ class CommandTool:
 
 
 TOOLS = [
-    CommandTool('flake8'),
+    CommandTool('flake8', default_files=('.',)),
     CommandTool(
         'isort', run_params=('-c',), fix_params=tuple(), default_files=('.',)
     ),


### PR DESCRIPTION
Without the default argument, it would always run on everything even if files are specified.