### PR TITLE
Add flake8-sfs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,10 @@ ignore=
     #B007,
     # Do not call assert False
     #B011
+    # Allow f-strings
+    SFS301,
+    # Allow .format
+    SFS201
 exclude=venv
 #max-complexity=2
 banned-modules=

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
         'flake8-no-u-prefixed-strings==0.2',
         'flake8-polyfill==1.0.2',
         'flake8-tidy-imports==4.4.1',
+        'flake8-sfs==0.0.3',
         'flake8-simplify==0.14.1',
         'isort==5.9.3',
         'mccabe==0.6.1',


### PR DESCRIPTION
Flake8-sfs https://pypi.org/project/flake8-sfs/ allows one to control which forms of string formatting code base can use. By default it forbids any form of string formatting and one needs to chose which ones are allowed.

See changes on this PR for example config adjustments that are necessary to start using it.