### PR TITLE
Drop python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 skip-string-normalization = true
-target-version = ['py36']
+target-version = ['py37']
 line-length = 79
 exclude = '''
 /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ line_length=79
 float_to_top=True
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 ignore_missing_imports = True
 no_implicit_optional = True
 strict_equality = True

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         'Operating System :: POSIX',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'lintlizard=lintlizard:main',


### PR DESCRIPTION
It's EOL already, and some [dependencies have dropped it too](https://github.com/closeio/lintlizard/pull/83).