### PR TITLE
Support markdown linters

### DIFF
--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -41,7 +41,6 @@ class CommandTool:
 
 TOOLS = [
     # Python source formatters
-    CommandTool('mypy'),
     CommandTool('flake8', default_files=()),
     CommandTool(
         'isort', run_params=('-c',), fix_params=(), default_files=('.',)
@@ -56,8 +55,8 @@ TOOLS = [
     # Markdown source formatters
     CommandTool(
         'mdformat',
-        run_params=('--check', '--number'),
-        fix_params=('--check',),
+        run_params=('--check',),
+        fix_params=(),
         default_files=('.',),
     ),
 ]

--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -48,11 +48,18 @@ TOOLS = [
     ),
     CommandTool('dmypy', run_params=('run',), ci_command=CommandTool('mypy')),
     CommandTool(
-        'black', run_params=('--check',), fix_params=(), default_files=('.',),
+        'black',
+        run_params=('--check',),
+        fix_params=(),
+        default_files=('.',),
     ),
-
     # Markdown source formatters
-    CommandTool('mdformat', run_params=('--check', '--number', '--wrap 60'))
+    CommandTool(
+        'mdformat',
+        run_params=('--check', '--number'),
+        fix_params=('--check',),
+        default_files=('.',),
+    ),
 ]
 
 

--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -40,17 +40,19 @@ class CommandTool:
 
 
 TOOLS = [
+    # Python source formatters
+    CommandTool('mypy'),
     CommandTool('flake8', default_files=()),
     CommandTool(
         'isort', run_params=('-c',), fix_params=(), default_files=('.',)
     ),
     CommandTool('dmypy', run_params=('run',), ci_command=CommandTool('mypy')),
     CommandTool(
-        'black',
-        run_params=('--check',),
-        fix_params=(),
-        default_files=('.',),
+        'black', run_params=('--check',), fix_params=(), default_files=('.',),
     ),
+
+    # Markdown source formatters
+    CommandTool('mdformat', run_params=('--check', '--number', '--wrap 60'))
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         'flake8-simplify==0.19.3',
         'isort==5.10.1',
         'mccabe==0.7.0',
+        'mdformat==0.7.16',
         'mypy==0.982',
         'mypy-extensions==0.4.3',
         'pathspec==0.10.1',


### PR DESCRIPTION
Addresses https://github.com/closeio/lintlizard/issues/56.

Couldn't find a way to pass the `--check` flag via the `mdformat` python sdk, so resorted to invoking the command via a `subprocess`.

/cc @jkemp101 