### PR TITLE
Revert mdformat

### DIFF
--- a/lintlizard/__init__.py
+++ b/lintlizard/__init__.py
@@ -52,13 +52,6 @@ TOOLS = [
         fix_params=(),
         default_files=('.',),
     ),
-    # Markdown source formatters
-    CommandTool(
-        'mdformat',
-        run_params=('--check',),
-        fix_params=(),
-        default_files=('.',),
-    ),
 ]
 
 


### PR DESCRIPTION
Reverting part of https://github.com/closeio/lintlizard/pull/133

We can't run `mdformat` automatically on `.` since it doesn't provide an option to ignore some files. It ends up formatting things in venvs and other unexpected places.

We still want to run it (possibly manually for now) and will re-add it later once lintlizard will be smarter about providing file lists, so I'm keeping it as a dependency.